### PR TITLE
homeworks/protocol: fix response parsing to ignore spurious message responses

### DIFF
--- a/protocol/system_command.go
+++ b/protocol/system_command.go
@@ -53,7 +53,7 @@ func System(ctx context.Context, s streamconn.Session, set bool, action SystemAc
 	if len(r) == 0 {
 		return "", ErrorNullParsedResponse
 	}
-	return r[0], nil
+	return r, nil
 }
 
 func SystemQuery(ctx context.Context, s streamconn.Session, action SystemActions) (string, error) {


### PR DESCRIPTION
The QS processor sends 'status/monitoring' outputs to all connected clients. Consequently the parsing of responses has to filter these out and return only the response for the issued command.