### PR TITLE
protocols/homeworks: some commands need to be special cased, and some do not expect a response

### DIFF
--- a/homeworks/shades.go
+++ b/homeworks/shades.go
@@ -65,8 +65,7 @@ func (sb hwShadeBase) operations(raise, lower, stop, set devices.Operation) map[
 }
 
 func (sb hwShadeBase) shadeCommand(ctx context.Context, s streamconn.Session, cg protocol.CommandGroup, pars []byte) error {
-	_, err := protocol.NewCommand(cg, true, pars).Call(ctx, s)
-	return err
+	return protocol.NewCommand(cg, true, pars).Invoke(ctx, s)
 }
 
 func (sb hwShadeBase) raiseShade(ctx context.Context, s streamconn.Session, cg protocol.CommandGroup) error {

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -53,7 +53,7 @@ func TestLogin(t *testing.T) {
 
 func TestParseResponse(t *testing.T) {
 
-	pr := func(i int, c, p, r string) string {
+	pr := func(i int, c, r string) string {
 		t.Helper()
 		line, err := protocol.ParseResponse([]byte(c), []byte(r))
 		if err != nil {
@@ -86,16 +86,16 @@ func TestParseResponse(t *testing.T) {
 		{"~SYSTEM,1,", "~SYSTEM,1,18:33:16\r", "18:33:16"},
 		{"~SYSTEM,2,", "~SYSTEM,2,11/17/2024\r", "11/17/2024"},
 	} {
-		if got, want := pr(i, tc.cmd, "QNET> ", withPrompt(tc.resp)), tc.want; got != want {
+		if got, want := pr(i, tc.cmd, withPrompt(tc.resp)), tc.want; got != want {
 			t.Errorf("%v: %v: got %v, want %v", i, tc.cmd, got, want)
 		}
-		if got, want := pr(i, tc.cmd, "QNET> ", withPrompt(extraResponses+tc.resp)), tc.want; got != want {
+		if got, want := pr(i, tc.cmd, withPrompt(extraResponses+tc.resp)), tc.want; got != want {
 			t.Errorf("%v: %v: got %v, want %v", i, tc.cmd, got, want)
 		}
-		if got, want := pr(i, tc.cmd, "QNET> ", withPrompt(extraResponses+tc.resp+"\r\n"+extraResponses)), tc.want; got != want {
+		if got, want := pr(i, tc.cmd, withPrompt(extraResponses+tc.resp+"\r\n"+extraResponses)), tc.want; got != want {
 			t.Errorf("%v: %v: got %v, want %v", i, tc.cmd, got, want)
 		}
-		if got, want := pr(i, tc.cmd, "QNET> ", withPrompt(extraResponses+tc.resp+"\r\n"+extraResponses)), tc.want; got != want {
+		if got, want := pr(i, tc.cmd, withPrompt(extraResponses+tc.resp+"\r\n"+extraResponses)), tc.want; got != want {
 			t.Errorf("%v: %v: got %v, want %v", i, tc.cmd, got, want)
 		}
 	}

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -55,7 +55,7 @@ func TestParseResponse(t *testing.T) {
 
 	pr := func(i int, c, p, r string) string {
 		t.Helper()
-		line, err := protocol.ParseResponse([]byte(c), []byte(p), []byte(r))
+		line, err := protocol.ParseResponse([]byte(c), []byte(r))
 		if err != nil {
 			t.Fatalf("unexpected error for case %v: %q: %v", i, c, err)
 		}

--- a/protocol/system_command.go
+++ b/protocol/system_command.go
@@ -46,6 +46,9 @@ func NormalizeTimeZone(tz string) string {
 // System sends a '[#?]System' command to the Lutron system.
 func System(ctx context.Context, s streamconn.Session, set bool, action SystemActions) (string, error) {
 	cmd := NewCommand(SystemCommands, set, []byte(strconv.Itoa(int(action))))
+	if action == SystemOSRev {
+		cmd.SetCustomResponse([]byte("OS Firmware Revision ="))
+	}
 	r, err := cmd.Call(ctx, s)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
1. all the expected response prefix to be customized
2. allow for commands that do not expect a response other than the prompt being reissued